### PR TITLE
FEAT: add localhost replacement

### DIFF
--- a/scraper/__main__.py
+++ b/scraper/__main__.py
@@ -30,14 +30,29 @@ def main(sys_args=None):
         help='The URL to the meilisearch host',
     )
 
+    parser.add_argument(
+        '--cname', type=str,
+        required=False,
+        help='The CNAME of the webpage',
+    )
+
+    parser.add_argument(
+        '--port', type=str,
+        required=False,
+        help='The port where local HTML files are served.',
+    )
+
     args = parser.parse_args()
 
     if args.meilisearch_host_url is not None:
         os.environ['MEILISEARCH_HOST_URL'] = args.meilisearch_host_url
     if args.meilisearch_api_key is not None:
         os.environ['MEILISEARCH_API_KEY'] = args.meilisearch_api_key
+    if args.cname is not None:
+        os.environ['DOCUMENTATION_CNAME'] = args.cname
+    if args.cname is not None:
+        os.environ['DOCUMENTATION_PORT'] = args.port
 
-    
     if 'MEILISEARCH_HOST_URL' not in os.environ:
         raise RuntimeError(
             '\n\nMEILISEARCH_HOST_URL is required either the command line argument:'

--- a/scraper/src/strategies/default_strategy.py
+++ b/scraper/src/strategies/default_strategy.py
@@ -2,6 +2,8 @@
 Default Strategy
 """
 
+import os
+
 from lxml.etree import XPath
 from .abstract_strategy import AbstractStrategy
 from .anchor import Anchor
@@ -205,6 +207,17 @@ class DefaultStrategy(AbstractStrategy):
                  'position': position}, sort_keys=True).encode('utf-8'))
             digest_hash = raw_hash.hexdigest()
             record['objectID'] = digest_hash
+
+            # Replace the localhost and the port with the desired CNAME
+            # Example:
+            # http://localhost:1314/index.html#pyansys-actions
+            cname = os.getenv("DOCUMENTATION_CNAME")
+            if cname is not None:
+                http, _, port_and_page = record["url"].split(":")
+                port = os.getenv("DOCUMENTATION_PORT")
+                path = port_and_page[len(port):]
+                record['url'] = f"{http}://{cname}{path}"
+
             records.append(record)
 
         return records


### PR DESCRIPTION
This pull-request allows to override the localhost and port prefix when scraping local documentation.